### PR TITLE
Support sample lengths of up to 32768 in the sample analyser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -355,9 +355,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "microfft"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556b5d8420cb2e761b21eedb5cae7525bf6838144151a3bec546e9969162dadc"
+checksum = "f2b6673eb0cc536241d6734c2ca45abfdbf90e9e7791c66a36a7ba3c315b76cf"
 dependencies = [
  "cfg-if",
  "num-complex",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "spectrum-analyzer"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9fa67f04b0a6424c19937498597aeb8a78fd9b20d3a010bc78b06f721f73e7"
+checksum = "7d06eea3d02718333cc1e726db92b5af1bf92e66f857f81268ff1633acd8a2d3"
 dependencies = [
  "float-cmp",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde_json = { version="1.0.97" }
 relative-path = { version="1.9.0", features=[ "serde" ] }
 
 sdl2 = { version="0.37.0", features=[] }
-spectrum-analyzer = { version="1.5.0" }
+spectrum-analyzer = { version="1.6.0" }
 
 fltk = { version="1.5.0", features = ["use-ninja"] }
 

--- a/crates/tad-gui/src/sample_analyser.rs
+++ b/crates/tad-gui/src/sample_analyser.rs
@@ -50,8 +50,8 @@ const BRR_SAMPLE_RATE: u32 = 32000;
 /// Minimum number of samples to render when decoding a looping BRR sample
 const MIN_LOOPING_SAMPLES: usize = 4096;
 
-/// spectrum-analyzer crate panics if samples.len() > 16384 samples
-const MAX_SPECTRUM_SAMPLES: usize = 16384;
+/// spectrum-analyzer crate panics if samples.len() > 32768 samples
+const MAX_SPECTRUM_SAMPLES: usize = 32768;
 
 /// Minimum number of waveform samples to show in the waveform widget
 const MIN_WAVEFORM_WIDTH: usize = 192;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,14 @@
 Terrific Audio Driver Changelog
 ===============================
 
+Version 0.0.16
+==============
+
+**Known bugs**:
+ * Sample Analyser spectrum can only analyse the first 32768 samples in a long BRR sample
+
+GUI changes:
+ * Sample Analyser can now analyse samples up to a length of 32768.
 
 Version 0.0.15
 ==============


### PR DESCRIPTION
The spectrum-analyzer crate was just recently updated to support FFT buffer sizes of 32768 once it was supported on microfft. Thus, we update the Cargo dependencies and adjust the maximum length supported by the spectrum analyser.