### PR TITLE
Handle noise frequency conflicts between music and SFX more gracefully

### DIFF
--- a/audio-driver/64tass-api/tad-process.inc
+++ b/audio-driver/64tass-api/tad-process.inc
@@ -44,7 +44,7 @@ TAD_DB_REGISTERS   = 0
 .cerror Tad_Loader_SIZE < 64 || Tad_Loader_SIZE > 128, "Invalid Tad_Loader_Bin size"
 .cerror (Tad_Loader_Bin >> 16) != ((Tad_Loader_Bin + Tad_Loader_SIZE) >> 16), "Tad_Loader_Bin does not fit inside a single bank"
 
-.cerror Tad_AudioDriver_SIZE < $600 || Tad_AudioDriver_SIZE > $b80, "Invalid Tad_AudioDriver_Bin size"
+.cerror Tad_AudioDriver_SIZE < $600 || Tad_AudioDriver_SIZE > $d00, "Invalid Tad_AudioDriver_Bin size"
 ; `Tad_AudioDriver_Bin` can cross bank boundaries
 
 .cerror Tad_BlankSong_SIZE != 31,"Invalid Tad_BlankSong_Bin size"

--- a/audio-driver/ca65-api/tad-audio.s
+++ b/audio-driver/ca65-api/tad-audio.s
@@ -121,7 +121,7 @@
 .assert Tad_Loader_SIZE > 64 && Tad_Loader_SIZE < 128, lderror, "Invalid Tad_Loader_Bin size"
 .assert .bankbyte(Tad_Loader_Bin) = .bankbyte(Tad_Loader_Bin + Tad_Loader_SIZE), lderror, "Tad_Loader_Bin does not fit inside a single bank"
 
-.assert Tad_AudioDriver_SIZE > $600 && Tad_AudioDriver_SIZE < $b80, lderror, "Invalid Tad_AudioDriver_Bin size"
+.assert Tad_AudioDriver_SIZE > $600 && Tad_AudioDriver_SIZE < $d00, lderror, "Invalid Tad_AudioDriver_Bin size"
 ; `Tad_AudioDriver_Bin` can cross bank boundaries
 
 .assert Tad_BlankSong_SIZE = 31, lderror, "Invalid Tad_BlankSong_Bin size"

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -958,6 +958,34 @@ var _afterFirstChannel : u8 in zpTmp2;
     y = a = ((nonShadow_music ^ nonShadow_sfx) & sfxMusicEchoNoiseMask) ^ nonShadow_music;
     write_dsp(GlobalDspAddr.NON, y);
 
+    //Prepare to immediately zero out the VxVOL DSP registers of all voices that don't have noise frequency priority if SFX is running.
+    //Trying to do this later could result in the volume stacking up until the next music tempo tick and/or not mute at all
+    //due to the order that the dirty bits are handled, as well as the dirty bit handling being delayed until the next tick.
+    //`_afterFirstChannel`'s purpose is done here and thus is subject to clobbering.
+    //X will remain set to _afterFirstChannel while the clearing is being done, as it is used in the upcoming loop.
+    y = noiseFreq_sfxVoiceId;
+    if !negative {
+        a = (activeSoundEffects ^ 0b11111111) & nonShadow_music;
+        zpTmp2 = a;
+        a = (ChannelVoiceBit[y] ^ 0b11000000) & nonShadow_sfx & activeSoundEffects;
+        test_and_set(a, zpTmp2);
+        a = 0;
+        y = a;
+        do {
+            zpTmp2 >>>= 1;
+            push(psw);
+            if carry {
+                smp.dsp_addr_and_data = ya; //Zero out VxVOLL.
+                a++;
+                smp.dsp_addr_and_data = ya; //Zero out VxVOLR.
+            }
+            psw = pop();
+            goto ExitNoiseVOLDSPClearLoop if zero;
+            a &= 0xf0;
+            a += 0x10;
+        } while !negative;
+        ExitNoiseVOLDSPClearLoop:
+    }
 
     write_dsp(GlobalDspAddr.KON, _konShadow);
 
@@ -1065,20 +1093,12 @@ var _afterFirstChannel : u8 in zpTmp2;
         if !zero {
             _process_volume_effects__inline(x, a);
 
-            // ::TODO optimise::
-            // Set S-DSP voice registers dirty bit
-            voiceChannelsDirty_tmp $ 7 = true;
-
             volShadowDirty_tmp $ 7 = true;
         }
 
         a = channelSoA.panEffect_direction[x];
         if !zero {
             _process_pan_effects__inline(x, a);
-
-            // ::TODO optimise::
-            // Set S-DSP voice registers dirty bit
-            voiceChannelsDirty_tmp $ 7 = true;
 
             volShadowDirty_tmp $ 7 = true;
         }
@@ -1716,8 +1736,23 @@ WritePan:
 // KEEP: x
 inline func _update_vol_shadow__inline(channelIndex : u8 in x) {
 
-    // ::TODO add global music/sfx volume::
-    a = channelSoA.volume[x];
+    a = (activeSoundEffects ^ 0b11111111) & nonShadow_music;
+    a |= nonShadow_sfx;
+    a &= ChannelVoiceBit[x];
+    cmp(a,1); //Set carry to whether this voice is using noise or not
+    a = activeSoundEffects & nonShadow_sfx;
+    if (carry && !zero) && ((x < FIRST_SFX_CHANNEL) || (x != noiseFreq_sfxVoiceId)) {
+        //This channel is using noise, but is either used in music or in a SFX voice
+        //that isn't the one currently controlling the hardware noise frequency.
+        //Due to hardware limitations, only one frequency can be running at a time.
+        //All other channels with non-zero volumes will instead stack up and make the noise louder than intended.
+        //Therefore, the volume value must be zeroed out instead.
+        a = 0;
+    }
+    else {
+        // ::TODO add global music/sfx volume::
+        a = channelSoA.volume[x];
+    }
 
     // Reading carry here saves a `SEC` instruction when calculating VOL_R
     carry = loaderDataType $ LoaderDataType.STEREO_FLAG_BIT;
@@ -1784,6 +1819,8 @@ inline func _update_vol_shadow__inline(channelIndex : u8 in x) {
     }
 
     channelSoA.virtualChannels.vol_l[x] = y;
+    // Set S-DSP voice registers dirty bit
+    voiceChannelsDirty_tmp $ 7 = true;
 }
 
 
@@ -2155,7 +2192,8 @@ func __play_note_set_pitch_h(channelIndex: u8 in x, pitch_h: u8 in a) {
         // Disable KON the next time the note is played (slur the note)
         test_and_clear(a, keyOnMask_sfx);
 
-        return;
+        // Because noise was disabled, update the frequency and volume settings.
+        ^return set_noise_freq_sfx_voice_id(x);
     }
 
     // Disable noise
@@ -2218,7 +2256,6 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
     if x >= FIRST_SFX_CHANNEL {
         (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[x] = y;
 
-        a = ChannelVoiceBit[x];
         test_and_set(a, nonShadow_sfx);
 
 
@@ -2228,17 +2265,44 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
         // Disable KON the next time the note is played (slur the note)
         test_and_clear(a, keyOnMask_sfx);
 
+        //Set volShadowDirty_music channel bits for each music channel that uses noise.
+        //These channels will have their volumes zeroed out by _update_vol_shadow.
+        set_voice_ch_dirty_music_to_non(x);
+
         a = noiseFreq_sfxVoiceId;
         if !negative {
-            goto PlayNoiseSFXReturn if x == noiseFreq_sfxVoiceId;
-            a = sfx_interruptibleFlags & ChannelVoiceBit[x];
-            goto PlayNoiseSFXReturn if !zero;
+            goto PlayNoiseReturn if x == noiseFreq_sfxVoiceId;
+            //Check the interruptible flag of the SFX instance currently handling the noise frequency.
+            //If the SFX instance is interruptible, the noise frequency is overwritten.
+            a = x;
+            a ^= 1;
+            y = a;
+            a = sfx_interruptibleFlags & ChannelVoiceBit[y];
+            goto PlayNoiseSFXReturn if zero;
         }
 
         noiseFreq_sfxVoiceId = x;
-        //TODO zero out VxVOL of conflicting music/SFX voice(s)
+
         PlayNoiseSFXReturn:
-            return;
+            a = ChannelVoiceBit[x];
+            a ^= 0b11111111;
+            a = a & activeSoundEffects & nonShadow_sfx;
+            if !zero {
+                //Zero out the VxVOL mirror of the SFX voice using noise but without noise frequency priority
+                //to avoid an edge case writing to the DSP registers when a voiceChannelsDirty bit is set.
+                a = x;
+                if x == noiseFreq_sfxVoiceId {
+                    a ^= 1;
+                }
+                y = a;
+                a = 0;
+                channelSoA.virtualChannels.vol_l[y] = a;
+                channelSoA.virtualChannels.vol_r[y] = a;
+            }
+            
+            //Set the corresponding volShadowDirty_sfx bits.
+            //These channels will have their volumes zeroed out or restored by _update_vol_shadow.
+            ^return set_voice_ch_dirty_sfx_to_non(x);
     }
 
     noiseFreq_music = y;
@@ -2251,18 +2315,21 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
 
     // Disable KON the next time the note is played (slur the note)
     test_and_clear(a, keyOnMask_music);
+
+PlayNoiseReturn:
 }
 
 // KEEP: X
 //Called in bytecode when either noise is disabled or when a SFX channel is disabled
+#[fallthrough]
 func set_noise_freq_sfx_voice_id(channelIndex: u8 in x) {
     if x == noiseFreq_sfxVoiceId {
         a = activeSoundEffects & nonShadow_sfx;
         if zero {
             noiseFreq_sfxVoiceId $ 7 = true;
             noiseFreq_music $ 7 = false; //Prepare music noise frequency for restoration
-            //TODO music VxVOL restoration
-            return;
+            //Setting dirty bits will restore the music volume
+            goto NoiseFreqSetDirtyVolShadowBits;
         }
         //Set the SFX voice ID that uses noise to the other one
         noiseFreq_sfxVoiceId ^= FIRST_SFX_CHANNEL ^ LAST_SFX_CHANNEL;
@@ -2270,10 +2337,42 @@ func set_noise_freq_sfx_voice_id(channelIndex: u8 in x) {
         a = (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y];
 	a &= 0b01111111;
         (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y] = a;
-        //TODO SFX VxVOL restoration
-    } 
+        //Setting dirty bits will restore the SFX volume
+    }
+    NoiseFreqSetDirtyVolShadowBits:
+        set_voice_ch_dirty_music_to_non(x);
+        //(fallthrough to set_voice_ch_dirty_sfx_to_non)
 }
 
+// KEEP: X
+//Called in bytecode to modify the volume for SFX channels after modifying SFX noise parameters.
+func set_voice_ch_dirty_sfx_to_non(channelIndex: u8 in x) {
+    //Always mark all SFX channels using noise as dirty, as well as the one currently being processed.
+    a = nonShadow_sfx & activeSoundEffects; //Set all active SFX voice bits that use noise as dirty.
+    a |= ChannelVoiceBit[x]; //Always set the current voice bit as dirty as well.
+    if a != 0b11000000 {
+      //Swap bits around via an EOR due to volShadowDirty using opposite bit ordering.
+      a ^= 0b11000000;
+    }
+    test_and_set(a, volShadowDirty_sfx);
+}
+
+// KEEP: X
+//Called in bytecode to modify the volume for music channels after modifying SFX noise parameters.
+func set_voice_ch_dirty_music_to_non(channelIndex: u8 in x) {
+    //Always mark all music channels using noise as dirty, as well as the one currently being processed.
+    a = nonShadow_music;
+    a |= ChannelVoiceBit[x];
+
+    //volShadowDirty_music's bits are represented in reverse order compared to nonShadow_music.
+    //Subsequently, we use zpTmp, then set them from there.
+    y = 8;
+    do {
+        a >>>= 1;
+        zpTmp <<<<#= 1;
+    } while --y != 0;
+    volShadowDirty_music |= zpTmp;
+}
 
 // KEEP: X
 func disable_noise(channelIndex: u8 in x) {

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -832,11 +832,6 @@ inline func _process_sfx_channels__inline() {
     // No need to mask sfx keyOff/keyOn events.
     // The sfx channels do not emit key-off or key-on events when disabled.
 
-
-    // Clear EON bits for disabled sfx channels here so EON is cleared after disable-channel key-off release tick.
-    eonShadow_sfx &= prevActiveSoundEffects;
-
-
     // Delay echo and noise changes 1 tick to prevent noise/echo changing in
     // the middle of the release envelope the channel is ducked or un-ducked.
     sfxMusicEchoNoiseMask = prevActiveSoundEffects;
@@ -847,7 +842,6 @@ inline func _process_sfx_channels__inline() {
     // Music channels can only write to the S-DSP when the sound effect is disabled AND there is no key-off event.
     // Prevents an audio glitch when a music channel writes to a voice channel in the middle of the key-off release envelope.
     musicSfxChannelMask = a = (a | keyOffShadow_sfx) ^ 0xff;
-
 
     write_dsp(GlobalDspAddr.KOFF, keyOffShadow_sfx);
 
@@ -997,7 +991,7 @@ var _afterFirstChannel : u8 in zpTmp2;
     }
 
 
-    y = a = (musicSfxChannelMask & eonShadow_music) | eonShadow_sfx;
+    y = a = ((eonShadow_music ^ eonShadow_sfx) & sfxMusicEchoNoiseMask) ^ eonShadow_music;
     write_dsp(GlobalDspAddr.EON, y);
 
     y = a = ((nonShadow_music ^ nonShadow_sfx) & sfxMusicEchoNoiseMask) ^ nonShadow_music;

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -588,17 +588,21 @@ func main() {
     } while !zero;
 
 
-    a = 0xff;
+    a--; //Decrement A from zero so that it is now 0xff.
     echoDirty = a;
     io_musicChannelsMask = a;
     musicSfxChannelMask = a;
     volShadowDirty_music = a;
     keyOnMask_music = a;
-    noiseFreq_music = a;
     noiseFreq_sfxVoiceId = a;
 
     inline for let _I in 0..(N_SFX_CHANNELS - 1) {
         sfx_oneChannelSfxId[_I] = a;
+    }
+
+    a = 0x80;
+    noiseFreq_music = a; //Set noise frequencies to zero with MSB set.
+    inline for let _I in 0..(N_SFX_CHANNELS - 1) {
         noiseFreq_sfx[_I] = a;
     }
 
@@ -2327,7 +2331,7 @@ func set_noise_freq_sfx_voice_id(channelIndex: u8 in x) {
         a = activeSoundEffects & nonShadow_sfx;
         if zero {
             noiseFreq_sfxVoiceId $ 7 = true;
-            noiseFreq_music $ 7 = false; //Prepare music noise frequency for restoration
+            noiseFreq_music &= dsp.FLG__NOISE_FREQ_MASK; //Prepare music noise frequency for restoration
             //Setting dirty bits will restore the music volume
             goto NoiseFreqSetDirtyVolShadowBits;
         }
@@ -2335,7 +2339,7 @@ func set_noise_freq_sfx_voice_id(channelIndex: u8 in x) {
         noiseFreq_sfxVoiceId ^= FIRST_SFX_CHANNEL ^ LAST_SFX_CHANNEL;
 	y = noiseFreq_sfxVoiceId; //Prepare SFX noise frequency for restoration
         a = (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y];
-	a &= 0b01111111;
+	a &= dsp.FLG__NOISE_FREQ_MASK;
         (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y] = a;
         //Setting dirty bits will restore the SFX volume
     }

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -832,6 +832,11 @@ inline func _process_sfx_channels__inline() {
     // No need to mask sfx keyOff/keyOn events.
     // The sfx channels do not emit key-off or key-on events when disabled.
 
+
+    // Clear EON bits for disabled sfx channels here so EON is cleared after disable-channel key-off release tick.
+    eonShadow_sfx &= prevActiveSoundEffects;
+
+
     // Delay echo and noise changes 1 tick to prevent noise/echo changing in
     // the middle of the release envelope the channel is ducked or un-ducked.
     sfxMusicEchoNoiseMask = prevActiveSoundEffects;
@@ -842,6 +847,7 @@ inline func _process_sfx_channels__inline() {
     // Music channels can only write to the S-DSP when the sound effect is disabled AND there is no key-off event.
     // Prevents an audio glitch when a music channel writes to a voice channel in the middle of the key-off release envelope.
     musicSfxChannelMask = a = (a | keyOffShadow_sfx) ^ 0xff;
+
 
     write_dsp(GlobalDspAddr.KOFF, keyOffShadow_sfx);
 
@@ -991,7 +997,7 @@ var _afterFirstChannel : u8 in zpTmp2;
     }
 
 
-    y = a = ((eonShadow_music ^ eonShadow_sfx) & sfxMusicEchoNoiseMask) ^ eonShadow_music;
+    y = a = (musicSfxChannelMask & eonShadow_music) | eonShadow_sfx;
     write_dsp(GlobalDspAddr.EON, y);
 
     y = a = ((nonShadow_music ^ nonShadow_sfx) & sfxMusicEchoNoiseMask) ^ nonShadow_music;

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -958,17 +958,14 @@ var _afterFirstChannel : u8 in zpTmp2;
     } while x >= _afterFirstChannel;
 
 
-    y = a = ((eonShadow_music ^ eonShadow_sfx) & sfxMusicEchoNoiseMask) ^ eonShadow_music;
-    write_dsp(GlobalDspAddr.EON, y);
-
-    y = a = ((nonShadow_music ^ nonShadow_sfx) & sfxMusicEchoNoiseMask) ^ nonShadow_music;
-    write_dsp(GlobalDspAddr.NON, y);
 
     //Prepare to immediately zero out the VxVOL DSP registers of all voices that don't have noise frequency priority if SFX is running.
     //Trying to do this later could result in the volume stacking up until the next music tempo tick and/or not mute at all
     //due to the order that the dirty bits are handled, as well as the dirty bit handling being delayed until the next tick.
     //`_afterFirstChannel`'s purpose is done here and thus is subject to clobbering.
     //X will remain set to _afterFirstChannel while the clearing is being done, as it is used in the upcoming loop.
+    //
+    //This is done before the EON write to ensure only one noise playing voice outputs noise.
     y = noiseFreq_sfxVoiceId;
     if !negative {
         a = (activeSoundEffects ^ 0b11111111) & nonShadow_music;
@@ -992,6 +989,14 @@ var _afterFirstChannel : u8 in zpTmp2;
         } while !negative;
         ExitNoiseVOLDSPClearLoop:
     }
+
+
+    y = a = ((eonShadow_music ^ eonShadow_sfx) & sfxMusicEchoNoiseMask) ^ eonShadow_music;
+    write_dsp(GlobalDspAddr.EON, y);
+
+    y = a = ((nonShadow_music ^ nonShadow_sfx) & sfxMusicEchoNoiseMask) ^ nonShadow_music;
+    write_dsp(GlobalDspAddr.NON, y);
+
 
     write_dsp(GlobalDspAddr.KON, _konShadow);
 

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -282,8 +282,11 @@ in zeropage {
     // noise frequency register shadow variables
     // (Value is only written to the flag register if MSB clear)
     var noiseFreq_music : u8;
-    var noiseFreq_sfx : u8;
+    var noiseFreq_sfx : [u8 ; N_SFX_CHANNELS];
 
+    // Current voice ID for SFX that is using noise.
+    // If MSB is set, then no SFX voices are using noise.
+    var noiseFreq_sfxVoiceId : u8;
 
 // --- All zeropage variables after `echo` are not cleared in main() ---
 
@@ -586,10 +589,11 @@ func main() {
     musicSfxChannelMask = a;
     keyOnMask_music = a;
     noiseFreq_music = a;
-    noiseFreq_sfx = a;
+    noiseFreq_sfxVoiceId = a;
 
     inline for let _I in 0..(N_SFX_CHANNELS - 1) {
         sfx_oneChannelSfxId[_I] = a;
+        noiseFreq_sfx[_I] = a;
     }
 
 
@@ -833,11 +837,15 @@ inline func _process_sfx_channels__inline() {
 
     write_dsp(GlobalDspAddr.KOFF, keyOffShadow_sfx);
 
-    y = noiseFreq_sfx;
+    x = noiseFreq_sfxVoiceId;
     if !negative {
-        // Assumes noiseFreq_sfx is <= dsp.FLG__NOISE_FREQ_MASK.
-        write_dsp(GlobalDspAddr.FLG, y);
-        noiseFreq_sfx $ 7 = true;
+        y = (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[x];
+        if !negative {
+            // Assumes noiseFreq_sfx is <= dsp.FLG__NOISE_FREQ_MASK.
+            write_dsp(GlobalDspAddr.FLG, y);
+            a = y | 0b10000000;
+            (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[x] = a;
+        }
     }
 
     zpTmp = keyOnShadow_sfx;
@@ -2206,7 +2214,7 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
     // queue KON if the previous note has been KOFFed
     a = ChannelVoiceBit[x];
     if x >= FIRST_SFX_CHANNEL {
-        noiseFreq_sfx = y;
+        (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[x] = y;
 
         a = ChannelVoiceBit[x];
         test_and_set(a, nonShadow_sfx);
@@ -2218,7 +2226,17 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
         // Disable KON the next time the note is played (slur the note)
         test_and_clear(a, keyOnMask_sfx);
 
-        return;
+        a = noiseFreq_sfxVoiceId;
+        if !negative {
+            goto PlayNoiseSFXReturn if x == noiseFreq_sfxVoiceId;
+            a = sfx_interruptibleFlags & ChannelVoiceBit[x];
+            goto PlayNoiseSFXReturn if !zero;
+        }
+
+        noiseFreq_sfxVoiceId = x;
+        //TODO zero out VxVOL of conflicting music/SFX voice(s)
+        PlayNoiseSFXReturn:
+            return;
     }
 
     noiseFreq_music = y;
@@ -2233,13 +2251,34 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
     test_and_clear(a, keyOnMask_music);
 }
 
+// KEEP: X
+//Called in bytecode when either noise is disabled or when a SFX channel is disabled
+func set_noise_freq_sfx_voice_id(channelIndex: u8 in x) {
+    if x == noiseFreq_sfxVoiceId {
+        a = activeSoundEffects & nonShadow_sfx;
+        if zero {
+            noiseFreq_sfxVoiceId $ 7 = true;
+            noiseFreq_music $ 7 = false; //Prepare music noise frequency for restoration
+            //TODO music VxVOL restoration
+            return;
+        }
+        //Set the SFX voice ID that uses noise to the other one
+        noiseFreq_sfxVoiceId ^= FIRST_SFX_CHANNEL ^ LAST_SFX_CHANNEL;
+	y = noiseFreq_sfxVoiceId; //Prepare SFX noise frequency for restoration
+        a = (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y];
+	a &= 0b01111111;
+        (&noiseFreq_sfx[-N_MUSIC_CHANNELS])[y] = a;
+        //TODO SFX VxVOL restoration
+    } 
+}
+
 
 // KEEP: X
 func disable_noise(channelIndex: u8 in x) {
     a = ChannelVoiceBit[x];
     if x >= FIRST_SFX_CHANNEL {
         test_and_clear(a, nonShadow_sfx);
-
+        set_noise_freq_sfx_voice_id(x);
         ^return process_next_bytecode(x);
     }
 
@@ -2490,6 +2529,9 @@ func disable_channel(channelIndex : u8 in x) {
 
         // Disable sfx S-DSP writes.
         test_and_clear(a, activeSoundEffects);
+
+        // Update the channel ID that uses a SFX noise frequency.
+	set_noise_freq_sfx_voice_id(x);
 
         // Clear `sfx_oneChannelSfxId` so the sfx can be restarted if it is not interruptible.
         (&sfx_oneChannelSfxId[-N_MUSIC_CHANNELS])[x] = a = 0xff;

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -264,20 +264,22 @@ in zeropage {
 
 
     // Used to determine if vol_l and vol_r need recalculating.
-    // In the `__process_channels()` loop, bit 7 is left-shifted out and the volume is updated if set.
+    // In the `__process_channels()` loop, bit 0 is right-shifted out and the volume is updated if set.
     // (bitfield)
     var volShadowDirty_tmp : u8;
 
     // Used to determine if all music channels should be updated.
-    //
-    // Must only contain 0x00 or 0xff.
-    //
-    // CAUTION: These bits are in reverse order, compared to other *_music bit-arrays.
+    // (bitfield - same order as the other *Shadow_music variables)
     var volShadowDirty_music : u8;
 
     // The sound effects with invalid vol_l and vol_r shadow variables.
-    // Set in the PLAY_SOUND_EFFECT command.
-    // CAUTION: bits 6 & 7 are swapped from other the other *_sfx bitsets
+    // Set in the PLAY_SOUND_EFFECT command and when noise is changed.
+    //
+    // CAUTION: Not in the same bit order as the other *_sfx bitfields.
+    //      ------ba
+    //       a = sfx channel 8
+    //       b = sfx channel 9
+    //
     // (bitfield)
     var volShadowDirty_sfx : u8;
 
@@ -1099,21 +1101,21 @@ var _afterFirstChannel : u8 in zpTmp2;
         if !zero {
             _process_volume_effects__inline(x, a);
 
-            volShadowDirty_tmp $ 7 = true;
+            volShadowDirty_tmp $ 0 = true;
         }
 
         a = channelSoA.panEffect_direction[x];
         if !zero {
             _process_pan_effects__inline(x, a);
 
-            volShadowDirty_tmp $ 7 = true;
+            volShadowDirty_tmp $ 0 = true;
         }
 
 
         // Cannot do this after process_bytecode() for 2 reasons:
         //  1. Volume must be calculated on the first instruction of a sound-effect
         //  2. Volume/pan slide/vibrato
-        volShadowDirty_tmp <<<= 1;
+        volShadowDirty_tmp >>>= 1;
         if carry {
             _update_vol_shadow__inline(x);
         }
@@ -1436,6 +1438,10 @@ inline func __play_sfx__inline(let _I : u8, sfx_id : u8 in y) : u8 in a {
     a <<<= 1;
     sfx_interruptibleFlags $ BIT = carry;
 
+    // Mark sfx channel volume dirty
+    // (volShadowDirty_sfx starts at the least-significant bit)
+    volShadowDirty_sfx $ _I = true;
+
 
     sfx_oneChannelSfxId[_I] = y;
 
@@ -1509,11 +1515,6 @@ func __play_sfx_on_channel(addrAndOneChannelFlag_h: u8 in a, channelIndex : u8 i
 
     // Enable sfx channel.
     test_and_set(a, activeSoundEffects);
-
-    // Mark sfx channel volume dirty
-    // eor used to swap bits 6 & 7 (since only 1 bit is set)
-    a ^= 0b11_000000;
-    test_and_set(a, volShadowDirty_sfx);
 
 
     // pan
@@ -2082,7 +2083,7 @@ namespace bytecode {
 // ASSUMES: in the channel process loop
 // KEEP: x
 inline func mark_vol_shadow_dirty__inline() {
-    volShadowDirty_tmp $ 7 = true;
+    volShadowDirty_tmp $ 0 = true;
 }
 
 
@@ -2366,10 +2367,10 @@ func set_voice_ch_dirty_sfx_to_non(channelIndex: u8 in x) {
     //Always mark all SFX channels using noise as dirty, as well as the one currently being processed.
     a = nonShadow_sfx & activeSoundEffects; //Set all active SFX voice bits that use noise as dirty.
     a |= ChannelVoiceBit[x]; //Always set the current voice bit as dirty as well.
-    if a != 0b11000000 {
-      //Swap bits around via an EOR due to volShadowDirty using opposite bit ordering.
-      a ^= 0b11000000;
-    }
+
+    // Move the 2 most significant bits to the least significant bits
+    // due to `volShadowDirty_sfx` starting at the LSB.
+    a <<<<#= 3;
     test_and_set(a, volShadowDirty_sfx);
 }
 
@@ -2380,14 +2381,7 @@ func set_voice_ch_dirty_music_to_non(channelIndex: u8 in x) {
     a = nonShadow_music;
     a |= ChannelVoiceBit[x];
 
-    //volShadowDirty_music's bits are represented in reverse order compared to nonShadow_music.
-    //Subsequently, we use zpTmp, then set them from there.
-    y = 8;
-    do {
-        a >>>= 1;
-        zpTmp <<<<#= 1;
-    } while --y != 0;
-    volShadowDirty_music |= zpTmp;
+    test_and_set(a, volShadowDirty_music);
 }
 
 

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -1039,6 +1039,7 @@ var _afterFirstChannel : u8 in zpTmp2;
                             if x >= FIRST_SFX_CHANNEL {
                                 test_and_set(a, keyOffShadow_sfx);
                                 test_and_set(a, keyOnMask_sfx);
+                                bytecode._disable_sfx_noise(x, a);
                             }
                             else {
                                 test_and_set(a, keyOffShadow_music);
@@ -1057,6 +1058,7 @@ var _afterFirstChannel : u8 in zpTmp2;
                 if x >= FIRST_SFX_CHANNEL {
                     test_and_set(a, keyOffShadow_sfx);
                     test_and_set(a, keyOnMask_sfx);
+                    bytecode._disable_sfx_noise(x, a);
                 }
                 else {
                     test_and_set(a, keyOffShadow_music);
@@ -2323,6 +2325,16 @@ func play_noise(channelIndex: u8 in x, freq_and_keyoff : u8 in a) {
 PlayNoiseReturn:
 }
 
+
+// KEEP: X
+#[fallthrough]
+func _disable_sfx_noise(channelIndex: u8 in x, voiceBit: u8 in a) {
+    test_and_clear(a, nonShadow_sfx);
+
+// Fallthrough into set_noise_freq_sfx_voice_id();
+}
+
+
 // KEEP: X
 //Called in bytecode when either noise is disabled or when a SFX channel is disabled
 #[fallthrough]
@@ -2378,12 +2390,12 @@ func set_voice_ch_dirty_music_to_non(channelIndex: u8 in x) {
     volShadowDirty_music |= zpTmp;
 }
 
+
 // KEEP: X
 func disable_noise(channelIndex: u8 in x) {
     a = ChannelVoiceBit[x];
     if x >= FIRST_SFX_CHANNEL {
-        test_and_clear(a, nonShadow_sfx);
-        set_noise_freq_sfx_voice_id(x);
+        _disable_sfx_noise(x, a);
         ^return process_next_bytecode(x);
     }
 

--- a/audio-driver/src/audio-driver.wiz
+++ b/audio-driver/src/audio-driver.wiz
@@ -790,11 +790,14 @@ func process_music_channels() {
 
     write_dsp(GlobalDspAddr.PMON, pmonShadow);
 
-    y = noiseFreq_music;
-    if !negative {
-        // Assumes noiseFreq_music is <= dsp.FLG__NOISE_FREQ_MASK.
-        write_dsp(GlobalDspAddr.FLG, y);
-        noiseFreq_music $ 7 = true;
+    a = activeSoundEffects & nonShadow_sfx;
+    if zero {
+        y = noiseFreq_music;
+        if !negative {
+            // Assumes noiseFreq_music is <= dsp.FLG__NOISE_FREQ_MASK.
+            write_dsp(GlobalDspAddr.FLG, y);
+            noiseFreq_music $ 7 = true;
+        }
     }
 
     zpTmp = a = keyOnShadow_music & musicSfxChannelMask & io_musicChannelsMask;

--- a/audio-driver/src/common_memmap.wiz
+++ b/audio-driver/src/common_memmap.wiz
@@ -41,6 +41,9 @@ let LAST_VAR_PAGE_SIZE = (BC_CHANNEL_STACK_SIZE + 9) * 10;
 
 // The -28 ensures the pitch-table and BRR directory is page aligned
 // `COMMON_DATA_ADDR` MUST be an even address (The loader only works with even addresses).
+//
+// If this value is changed, the Tad_loader_Bin assert in `ca65-api/tad-audio.s` and
+// `64tass-api/tad-process.inc` should also be updated.
 let COMMON_DATA_ADDR = 0x1000 - 28;
 
 // `CODE_ADDR` MUST be an even address (The loader only works with even addresses)

--- a/audio-driver/src/common_memmap.wiz
+++ b/audio-driver/src/common_memmap.wiz
@@ -41,7 +41,7 @@ let LAST_VAR_PAGE_SIZE = (BC_CHANNEL_STACK_SIZE + 9) * 10;
 
 // The -28 ensures the pitch-table and BRR directory is page aligned
 // `COMMON_DATA_ADDR` MUST be an even address (The loader only works with even addresses).
-let COMMON_DATA_ADDR = 0xF00 - 28;
+let COMMON_DATA_ADDR = 0x1000 - 28;
 
 // `CODE_ADDR` MUST be an even address (The loader only works with even addresses)
 let CODE_ADDR = 0x200 + LOADER_SIZE;

--- a/crates/compiler/src/driver_constants.rs
+++ b/crates/compiler/src/driver_constants.rs
@@ -92,7 +92,7 @@ pub mod addresses {
     );
 
     // MUST match `audio-driver/src/common_memmap.wiz`
-    pub const COMMON_DATA: u16 = 0xF00 - 28;
+    pub const COMMON_DATA: u16 = 0x1000 - 28;
 
     const _: () = assert!(
         _symbols::_LAST_LOADER_SYMBOL < DRIVER_CODE,

--- a/examples/example-project.terrificaudio
+++ b/examples/example-project.terrificaudio
@@ -142,6 +142,7 @@
     "robot_fires_laser",
     "fire_arrow",
     "noise",
+    "noise_and_rest",
     "sfx_calling_subroutine_asm",
     "sfx_calling_subroutine_mml"
   ],

--- a/examples/example-project.terrificaudio
+++ b/examples/example-project.terrificaudio
@@ -143,6 +143,8 @@
     "fire_arrow",
     "noise",
     "noise_and_rest",
+    "beep_and_noise",
+    "noise_nokeyoff_release_test",
     "sfx_calling_subroutine_asm",
     "sfx_calling_subroutine_mml"
   ],

--- a/examples/sound-effects.txt
+++ b/examples/sound-effects.txt
@@ -144,6 +144,24 @@ A @1 o5 [c c c r]4
 	play_noise 31 keyoff 12
 	rest 250
 
+=== beep_and_noise ===
+; Bugtest
+; Test play_noise release envelope keeps the noise bit set
+
+    set_instrument_and_gain sine F127
+    set_volume 255
+    play_note a4 8
+    play_noise 31 keyoff 12
+
+=== noise_nokeyoff_release_test ===
+; Bugtest
+; Test play_noise release envelope when channel is disabled
+
+    set_instrument_and_gain sine F127
+    set_volume 255
+    play_note a4 8
+    play_noise 31 no_keyoff 12
+
 === sfx_calling_subroutine_asm ===
 
 	set_instrument square

--- a/examples/sound-effects.txt
+++ b/examples/sound-effects.txt
@@ -135,7 +135,7 @@ A @1 o5 [c c c r]4
 
 	play_noise 31 12
 
-=== noise_and_rest === one interruptible
+=== noise_and_rest === both uninterruptible
 ; Bugfix test
 ; Used to test if noise is disabled on key-off
 

--- a/examples/sound-effects.txt
+++ b/examples/sound-effects.txt
@@ -135,6 +135,15 @@ A @1 o5 [c c c r]4
 
 	play_noise 31 12
 
+=== noise_and_rest === one interruptible
+; Bugfix test
+; Used to test if noise is disabled on key-off
+
+	set_instrument_and_gain sine F127
+
+	play_noise 31 keyoff 12
+	rest 250
+
 === sfx_calling_subroutine_asm ===
 
 	set_instrument square


### PR DESCRIPTION
This pull request upgrades the sound driver's ability to handle conflicts between music and SFX with noise involved. This has to be done because the hardware only supports one noise frequency at a time. The sound driver currently tracks two, and a third one has been added one so that each SFX instance has its own noise frequency. Priority is handled via the interruptibility flags: if it is uninterruptible, then the noise SFX will not be interrupted until the noise is done being used for the moment.

Test case used: [NoiseTest.zip](https://github.com/user-attachments/files/18388074/NoiseTest.zip)
