### PR TITLE
Lower the lowest octave offset by 1 octave

### DIFF
--- a/crates/compiler/src/pitch_table.rs
+++ b/crates/compiler/src/pitch_table.rs
@@ -34,7 +34,7 @@ const SPC_SAMPLE_RATE: u32 = 32000;
 const MIN_SAMPLE_FREQ: f64 = 27.5; // a0
 const MAX_SAMPLE_FREQ: f64 = (SPC_SAMPLE_RATE / 2) as f64;
 
-const MIN_MIN_OCTAVE_OFFSET: i32 = -6;
+const MIN_MIN_OCTAVE_OFFSET: i32 = -7;
 
 const PITCH_REGISTER_FP_SCALE: u32 = 0x1000;
 pub const PITCH_REGISTER_MAX: u16 = 0x3fff;


### PR DESCRIPTION
There is a practical limit for how low this can go because eventually you'll run into precision limitations that will cause identical VxPITCH values to be output, potentially wasting pitch table entries in the process. I determined that I could go one octave lower without creating duplicate VxPITCH values due to these precision limitations.

This is also because I occasionally use extremely low notes with single BRR block samples, and certain samples that get small enough (or are the hardware overflow glitch test sample used in the Factory Theme of unnamed-snes-game, which for melodic usage actually has one of the highest pitches that can be achieved not counting the resulting aliasing) actually have enough precision limitations to require such a low octave in order to access those lower pitches.